### PR TITLE
Add Claude Code Maven-version validation hook

### DIFF
--- a/.claude/hooks/validate-maven-versions.sh
+++ b/.claude/hooks/validate-maven-versions.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# PreToolUse hook: validates Maven Central GAVs in build files before Edit/Write commits them.
+#
+# Reads tool input as JSON on stdin, extracts file path + proposed content, scans for
+# Gradle string-notation dependencies (group:artifact:version), and checks repo1.maven.org
+# directly with a HEAD request. Exits 2 to BLOCK only when the registry returns 404.
+# Exits 0 (allow) on network failure, timeout, missing tools, or any ambiguity — we
+# never want this hook to block real work because the network is slow.
+#
+# Why direct repo lookups instead of solrsearch: solrsearch is slow (often >5s per
+# request) and sometimes misses recent versions. A HEAD on repo1.maven.org/maven2 is
+# fast and authoritative.
+#
+# Why this exists: prior sessions referenced library versions that didn't exist on
+# Maven Central (e.g. vertx-junit5 5.1.0), forcing rework across multiple files.
+
+set -u
+
+command -v jq   >/dev/null 2>&1 || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+
+PAYLOAD="$(cat)"
+[ -z "$PAYLOAD" ] && exit 0
+
+TOOL_NAME="$(printf '%s' "$PAYLOAD" | jq -r '.tool_name // empty' 2>/dev/null)"
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH="$(printf '%s' "$PAYLOAD" | jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+[ -z "$FILE_PATH" ] && exit 0
+
+case "$FILE_PATH" in
+  *.gradle|*.gradle.kts|*.toml|*pom.xml) ;;
+  *) exit 0 ;;
+esac
+
+CANDIDATE="$(printf '%s' "$PAYLOAD" | jq -r '
+  (.tool_input.new_string // "") + "\n" +
+  (.tool_input.content    // "") + "\n" +
+  ((.tool_input.edits // []) | map(.new_string // "") | join("\n"))
+' 2>/dev/null)"
+
+[ -z "$CANDIDATE" ] && exit 0
+
+# Match "group:artifact:version" in single or double quotes.
+# group/artifact: alnum + . _ -; must start with a letter.
+# version: must start with a digit (filters out variable refs like $version).
+GAVS="$(
+  printf '%s' "$CANDIDATE" \
+  | grep -oE "['\"][a-zA-Z][a-zA-Z0-9._-]+:[a-zA-Z][a-zA-Z0-9._-]+:[0-9][a-zA-Z0-9._+-]+['\"]" \
+  | tr -d "'\"" \
+  | sort -u
+)"
+
+[ -z "$GAVS" ] && exit 0
+
+MISSING=""
+while IFS= read -r gav; do
+  [ -z "$gav" ] && continue
+  GROUP="${gav%%:*}"
+  REST="${gav#*:}"
+  ARTIFACT="${REST%%:*}"
+  VERSION="${REST#*:}"
+  [ -z "$GROUP" ] || [ -z "$ARTIFACT" ] || [ -z "$VERSION" ] && continue
+
+  # group dots become path slashes
+  GROUP_PATH="${GROUP//.//}"
+  URL="https://repo1.maven.org/maven2/${GROUP_PATH}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}.pom"
+
+  # HEAD with 5s timeout. -I = HEAD; -o /dev/null discards body. -w prints status code.
+  STATUS="$(curl -sS -I -o /dev/null -w "%{http_code}" --max-time 5 "$URL" 2>/dev/null)"
+
+  case "$STATUS" in
+    200) ;;            # found, ok
+    404) MISSING="${MISSING}${gav}"$'\n' ;;
+    *)   ;;            # network failure / timeout / 5xx — allow, don't block
+  esac
+done <<<"$GAVS"
+
+if [ -n "$MISSING" ]; then
+  {
+    echo "Maven Central does not have these dependencies referenced in $FILE_PATH:"
+    printf '%s' "$MISSING" | sed 's/^/  - /'
+    echo
+    echo "Verify the group:artifact:version exists on https://search.maven.org/ before committing."
+    echo "If this is a private/internal artifact, the user can override by accepting the edit."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/validate-maven-versions.sh
+++ b/.claude/hooks/validate-maven-versions.sh
@@ -56,33 +56,34 @@ GAVS="$(
 
 [ -z "$GAVS" ] && exit 0
 
-MISSING=""
-while IFS= read -r gav; do
-  [ -z "$gav" ] && continue
-  GROUP="${gav%%:*}"
-  REST="${gav#*:}"
-  ARTIFACT="${REST%%:*}"
-  VERSION="${REST#*:}"
-  [ -z "$GROUP" ] || [ -z "$ARTIFACT" ] || [ -z "$VERSION" ] && continue
-
-  # group dots become path slashes
-  GROUP_PATH="${GROUP//.//}"
-  URL="https://repo1.maven.org/maven2/${GROUP_PATH}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}.pom"
-
-  # HEAD with 5s timeout. -I = HEAD; -o /dev/null discards body. -w prints status code.
-  STATUS="$(curl -sS -I -o /dev/null -w "%{http_code}" --max-time 5 "$URL" 2>/dev/null)"
-
-  case "$STATUS" in
-    200) ;;            # found, ok
-    404) MISSING="${MISSING}${gav}"$'\n' ;;
-    *)   ;;            # network failure / timeout / 5xx — allow, don't block
-  esac
-done <<<"$GAVS"
+# Probe each GAV in parallel — sequential lookups dominate wall time when several
+# dependencies change at once. xargs -P fans out HEAD requests with bounded concurrency.
+# NUL-delimited input + -n 1 hands each GAV to the worker as a positional argument
+# ($1), so no part of the candidate content is ever interpolated into a shell command
+# string — defense-in-depth even though the regex above already strips metacharacters.
+# Each worker prints the GAV iff Maven Central returns 404; anything else (200, network
+# failure, timeout, 5xx) is allowed silently.
+MISSING="$(
+  printf '%s' "$GAVS" | tr '\n' '\0' \
+  | xargs -0 -P 8 -n 1 bash -c '
+      gav="$1"
+      [ -z "$gav" ] && exit 0
+      group="${gav%%:*}"
+      rest="${gav#*:}"
+      artifact="${rest%%:*}"
+      version="${rest#*:}"
+      group_path="${group//.//}"
+      url="https://repo1.maven.org/maven2/${group_path}/${artifact}/${version}/${artifact}-${version}.pom"
+      status="$(curl -sS -I -o /dev/null -w "%{http_code}" --max-time 5 "$url" 2>/dev/null)"
+      [ "$status" = "404" ] && printf "%s\n" "$gav"
+      exit 0
+    ' _
+)"
 
 if [ -n "$MISSING" ]; then
   {
     echo "Maven Central does not have these dependencies referenced in $FILE_PATH:"
-    printf '%s' "$MISSING" | sed 's/^/  - /'
+    printf '%s\n' "$MISSING" | sed 's/^/  - /'
     echo
     echo "Verify the group:artifact:version exists on https://search.maven.org/ before committing."
     echo "If this is a private/internal artifact, the user can override by accepting the edit."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-maven-versions.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bin/
 ### Mac OS ###
 .DS_Store
 /.idea/
+
+### Claude Code (local-only) ###
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds a PreToolUse hook (`.claude/hooks/validate-maven-versions.sh`) that scans Edit/Write/MultiEdit payloads targeting `*.gradle`, `*.gradle.kts`, `*.toml`, or `pom.xml` for `group:artifact:version` strings and HEAD-checks each one against `repo1.maven.org`. Blocks the tool (exit 2) only on a 404; allows on every other ambiguity (network failure, timeout, missing tools, 5xx) so transient issues never stall real work. Motivated by prior sessions referencing nonexistent versions (e.g. vertx-junit5 5.1.0) and forcing rework.
- Wires the hook into Claude Code via `.claude/settings.json` and ignores `.claude/settings.local.json` in `.gitignore`.
- HEAD probes run in parallel via `xargs -0 -P 8 -n 1` (NUL-delimited, positional `$1`) so several dependency edits validate in roughly the wall time of one request, and no candidate content is ever interpolated into a shell command string.

## Test plan
- [x] Smoke-tested with a mixed payload (one valid junit GAV + one fabricated `com.fake:nonexistent-artifact:99.99.99`) — valid passed, invalid blocked with exit 2 and a clear stderr message; total wall time ~0.4s.
- [ ] Land and confirm the hook fires on a real Edit to `gradle/libs.versions.toml` in a follow-up session.
- [ ] Confirm the hook stays out of the way (exit 0) when `jq` or `curl` is missing on a fresh machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)