### PR TITLE
test: expand repoMaintenance coverage and bump static-analysis to 2.34.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,8 @@ junit-jupiter = "5.14.1"
 junit-platform-launcher = "1.10.2"
 openrewrite-bom = "8.80.1"
 openrewrite-gradle-plugin = "7.23.0"
+rewrite-migrate-java = "3.34.0"
+rewrite-static-analysis = "2.34.0"
 assertj-core = "3.27.7"
 jackson-core = "2.18.6"
 
@@ -10,13 +12,12 @@ jackson-core = "2.18.6"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform-launcher" }
-openrewrite-bom = { module = "org.openrewrite:rewrite-bom", version.ref = "openrewrite-bom" }
 openrewrite-java = { module = "org.openrewrite:rewrite-java" }
 openrewrite-gradle = { module = "org.openrewrite:rewrite-gradle" }
 openrewrite-yaml = { module = "org.openrewrite:rewrite-yaml" }
 openrewrite-java21 = { module = "org.openrewrite:rewrite-java-25" }
-openrewrite-migrate-java = { module = "org.openrewrite.recipe:rewrite-migrate-java", version = "3.34.0" }
-openrewrite-static-analysis = { module = "org.openrewrite.recipe:rewrite-static-analysis", version = "2.11.0" }
+openrewrite-migrate-java = { module = "org.openrewrite.recipe:rewrite-migrate-java", version.ref = "rewrite-migrate-java" }
+openrewrite-static-analysis = { module = "org.openrewrite.recipe:rewrite-static-analysis", version.ref = "rewrite-static-analysis" }
 openrewrite-test = { module = "org.openrewrite:rewrite-test" }
 openrewrite-json = { module = "org.openrewrite:rewrite-json" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-core" }

--- a/src/test/java/com/rewrite/repoMaintenance/checkstyle/CheckstyleAutoFormatRecipeTest.java
+++ b/src/test/java/com/rewrite/repoMaintenance/checkstyle/CheckstyleAutoFormatRecipeTest.java
@@ -231,6 +231,60 @@ class CheckstyleAutoFormatRecipeTest implements RewriteTest {
     }
 
     @Test
+    void equalsAvoidsNullSwapsLiteralOrder() {
+        rewriteRun(
+                java(
+                        """
+                        package com.example;
+                        public class A {
+                          public boolean m(String s) {
+                            return s.equals("foo");
+                          }
+                        }
+                        """,
+                        // EqualsAvoidsNull rewrites s.equals("foo") to "foo".equals(s) so a null
+                        // receiver no longer NPEs. AutoFormat reformats indentation to 4 spaces and
+                        // adds a blank line after package; EmptyNewlineAtEndOfFile adds trailing \n.
+                        """
+                        package com.example;
+
+                        public class A {
+                            public boolean m(String s) {
+                                return "foo".equals(s);
+                            }
+                        }
+
+                        """
+                )
+        );
+    }
+
+    @Test
+    void cStyleArrayDeclarationConvertedToJavaStyle() {
+        rewriteRun(
+                java(
+                        """
+                        package com.example;
+                        public class A {
+                          public int x[] = new int[]{1, 2};
+                        }
+                        """,
+                        // UseJavaStyleArrayDeclarations moves the brackets from the variable name
+                        // to the type, leaving a residual space ("public  int[]") that AutoFormat
+                        // does not collapse. The double space is the recipe's actual output today.
+                        """
+                        package com.example;
+
+                        public class A {
+                            public  int[] x = new int[]{1, 2};
+                        }
+
+                        """
+                )
+        );
+    }
+
+    @Test
     void alreadyFormattedFileIsNoOp() {
         rewriteRun(
                 java(

--- a/src/test/java/com/rewrite/repoMaintenance/dependencies/DependencyVersionConstantsTest.java
+++ b/src/test/java/com/rewrite/repoMaintenance/dependencies/DependencyVersionConstantsTest.java
@@ -1,0 +1,44 @@
+package com.rewrite.repoMaintenance.dependencies;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DependencyVersionConstantsTest {
+
+    @Test
+    void dependenciesIncludeVertxAndSpring() {
+        assertThat(DependencyVersionConstants.DEPENDENCIES)
+                .extracting(DependencyVersionConstants.Gav::groupId,
+                        DependencyVersionConstants.Gav::artifactId,
+                        DependencyVersionConstants.Gav::newVersion)
+                .containsExactlyInAnyOrder(
+                        org.assertj.core.groups.Tuple.tuple("io.vertx", "vertx-core", "5.0.5"),
+                        org.assertj.core.groups.Tuple.tuple("org.springframework", "spring-core", "6.2.0"));
+    }
+
+    @Test
+    void pluginsIncludeSpringBoot() {
+        assertThat(DependencyVersionConstants.PLUGINS)
+                .extracting(DependencyVersionConstants.PluginUpgrade::pluginId,
+                        DependencyVersionConstants.PluginUpgrade::newVersion)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("org.springframework.boot", "3.4.0"));
+    }
+
+    @Test
+    void gavRecordImplementsValueEquality() {
+        DependencyVersionConstants.Gav a = new DependencyVersionConstants.Gav("g", "a", "1.0");
+        DependencyVersionConstants.Gav b = new DependencyVersionConstants.Gav("g", "a", "1.0");
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+    }
+
+    @Test
+    void pluginUpgradeRecordImplementsValueEquality() {
+        DependencyVersionConstants.PluginUpgrade a =
+                new DependencyVersionConstants.PluginUpgrade("p", "1.0");
+        DependencyVersionConstants.PluginUpgrade b =
+                new DependencyVersionConstants.PluginUpgrade("p", "1.0");
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+    }
+}

--- a/src/test/java/com/rewrite/repoMaintenance/dependencies/UpgradeProjectDependenciesRecipeTest.java
+++ b/src/test/java/com/rewrite/repoMaintenance/dependencies/UpgradeProjectDependenciesRecipeTest.java
@@ -100,6 +100,52 @@ class UpgradeProjectDependenciesRecipeTest implements RewriteTest {
     }
 
     @Test
+    void springCoreUpgradeInBuildGradle() {
+        rewriteRun(
+                buildGradle(
+                        """
+                        plugins { id 'java' }
+                        repositories { mavenCentral() }
+                        dependencies {
+                            implementation 'org.springframework:spring-core:6.0.0'
+                        }
+                        """,
+                        """
+                        plugins { id 'java' }
+                        repositories { mavenCentral() }
+                        dependencies {
+                            implementation 'org.springframework:spring-core:6.2.0'
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void multipleDependenciesUpgradedTogether() {
+        rewriteRun(
+                buildGradle(
+                        """
+                        plugins { id 'java' }
+                        repositories { mavenCentral() }
+                        dependencies {
+                            implementation 'io.vertx:vertx-core:3.9.16'
+                            implementation 'org.springframework:spring-core:6.0.0'
+                        }
+                        """,
+                        """
+                        plugins { id 'java' }
+                        repositories { mavenCentral() }
+                        dependencies {
+                            implementation 'io.vertx:vertx-core:5.0.5'
+                            implementation 'org.springframework:spring-core:6.2.0'
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
     void noOpWhenAlreadyAtTargetVersion() {
         rewriteRun(
                 buildGradle(

--- a/src/test/java/com/rewrite/repoMaintenance/lambdaJson/LambdaJsonConstantsTest.java
+++ b/src/test/java/com/rewrite/repoMaintenance/lambdaJson/LambdaJsonConstantsTest.java
@@ -1,0 +1,37 @@
+package com.rewrite.repoMaintenance.lambdaJson;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LambdaJsonConstantsTest {
+
+    @Test
+    void filePatternMatchesBothLayouts() {
+        assertThat(LambdaJsonConstants.FILE_PATTERN).isEqualTo("**/config/*/lambda.json");
+    }
+
+    @Test
+    void runtimeTargetIsJava25() {
+        assertThat(LambdaJsonConstants.RUNTIME_PATH).isEqualTo("$.runtime");
+        assertThat(LambdaJsonConstants.RUNTIME_VALUE).isEqualTo("java25");
+    }
+
+    @Test
+    void handlerTargetIsExampleHandler() {
+        assertThat(LambdaJsonConstants.HANDLER_PATH).isEqualTo("$.handler");
+        assertThat(LambdaJsonConstants.HANDLER_VALUE).isEqualTo("com.example.Handler");
+    }
+
+    @Test
+    void regionPathPreservesIntentionalMisspelling() {
+        assertThat(LambdaJsonConstants.REGION_PATH).isEqualTo("$.deploymentCordinates.region");
+        assertThat(LambdaJsonConstants.REGION_VALUE).isEqualTo("us-east-1");
+    }
+
+    @Test
+    void deletePathsTargetTopLevelKeys() {
+        assertThat(LambdaJsonConstants.DELETE_FUNCTION_VERSION_PATH).isEqualTo("$.functionVersion");
+        assertThat(LambdaJsonConstants.DELETE_VERSION_PATH).isEqualTo("$.version");
+    }
+}

--- a/src/test/java/com/rewrite/repoMaintenance/lambdaJson/UpdateLambdaJsonRecipeTest.java
+++ b/src/test/java/com/rewrite/repoMaintenance/lambdaJson/UpdateLambdaJsonRecipeTest.java
@@ -130,6 +130,80 @@ class UpdateLambdaJsonRecipeTest implements RewriteTest {
     }
 
     @Test
+    void partialUpdateOnlyTouchesIncorrectKeys() {
+        rewriteRun(
+                json(
+                        """
+                        {
+                          "runtime": "java25",
+                          "handler": "old.Handler",
+                          "deploymentCordinates": {
+                            "region": "us-east-1"
+                          }
+                        }
+                        """,
+                        """
+                        {
+                          "runtime": "java25",
+                          "handler": "com.example.Handler",
+                          "deploymentCordinates": {
+                            "region": "us-east-1"
+                          }
+                        }
+                        """,
+                        spec -> spec.path("config/myfunc/lambda.json")
+                )
+        );
+    }
+
+    @Test
+    void deletesOnlyVersionWhenFunctionVersionAbsent() {
+        rewriteRun(
+                json(
+                        """
+                        {
+                          "runtime": "nodejs18.x",
+                          "version": "1.2",
+                          "handler": "old.Handler"
+                        }
+                        """,
+                        """
+                        {
+                          "runtime": "java25",
+                          "handler": "com.example.Handler"
+                        }
+                        """,
+                        spec -> spec.path("config/myfunc/lambda.json")
+                )
+        );
+    }
+
+    @Test
+    void preservesUnrelatedTopLevelKeys() {
+        rewriteRun(
+                json(
+                        """
+                        {
+                          "runtime": "nodejs18.x",
+                          "handler": "old.Handler",
+                          "memory": 512,
+                          "timeout": 30
+                        }
+                        """,
+                        """
+                        {
+                          "runtime": "java25",
+                          "handler": "com.example.Handler",
+                          "memory": 512,
+                          "timeout": 30
+                        }
+                        """,
+                        spec -> spec.path("config/myfunc/lambda.json")
+                )
+        );
+    }
+
+    @Test
     void recipeMetadataAndCompositeSize() {
         UpdateLambdaJsonRecipe recipe = new UpdateLambdaJsonRecipe();
         assertThat(recipe.getDisplayName()).isNotBlank();


### PR DESCRIPTION
## Summary
- Bump `rewrite-static-analysis` 2.11.0 → 2.34.0 and convert `rewrite-migrate-java` to a `version.ref` entry; drop unused `openrewrite-bom` library alias (build.gradle resolves the BOM coordinates directly via `libs.versions.openrewrite.bom.get()`).
- Add `LambdaJsonConstantsTest` and `DependencyVersionConstantsTest` that pin the public constants (incl. the intentional `Cordinates` misspelling) and verify record value-equality.
- Extend `UpdateLambdaJsonRecipeTest` with partial-update, single-key deletion, and unrelated-top-level-key preservation cases.
- Extend `UpgradeProjectDependenciesRecipeTest` with `spring-core` upgrade and a multi-dependency upgrade case.
- Extend `CheckstyleAutoFormatRecipeTest` with `EqualsAvoidsNull` and `UseJavaStyleArrayDeclarations` cases (the latter intentionally pins the residual double-space the recipe leaves after moving brackets).

`RedundantModifier` is still absent in `rewrite-static-analysis` 2.34.0, so the existing `@Disabled` test for it remains valid.

## Test plan
- [ ] `./gradlew clean test` — expect 84 tests, 0 failures, 5 skipped.
- [ ] `./gradlew test --tests 'com.rewrite.repoMaintenance.*'` — all repoMaintenance tests green.
- [ ] `./gradlew test --tests 'com.rewrite.repoMaintenance.lambdaJson.UpdateLambdaJsonRecipeTest.deletesOnlyVersionWhenFunctionVersionAbsent'` — confirms only `version` is removed.
- [ ] `./gradlew test --tests 'com.rewrite.repoMaintenance.checkstyle.CheckstyleAutoFormatRecipeTest.cStyleArrayDeclarationConvertedToJavaStyle'` — documents the double-space output.